### PR TITLE
Add auto link headers

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 require("dotenv").config({
   path: `.env`,
 });
@@ -49,6 +50,7 @@ module.exports = {
       resolve: `gatsby-plugin-mdx`,
       options: {
         extensions: [`.mdx`, `.md`],
+        gatsbyRemarkPlugins: [`gatsby-remark-autolink-headers`],
         plugins: [
           {
             resolve: `gatsby-remark-prismjs`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12864,6 +12864,36 @@
         }
       }
     },
+    "gatsby-remark-autolink-headers": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-2.3.11.tgz",
+      "integrity": "sha512-jYGgZ+NTbVxJmyS6z1oojWxOR12R7MGl4jM5aOXSmPuTSo8gbpm3aW7l5XMyud5fDDdP3xfbYuTX4RvBUWrx7g==",
+      "requires": {
+        "@babel/runtime": "^7.10.3",
+        "github-slugger": "^1.3.0",
+        "lodash": "^4.17.15",
+        "mdast-util-to-string": "^1.1.0",
+        "unist-util-visit": "^1.4.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "unist-util-visit": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
+          }
+        }
+      }
+    },
     "gatsby-remark-external-links": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/gatsby-remark-external-links/-/gatsby-remark-external-links-0.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "gatsby-plugin-sharp": "^2.6.25",
     "gatsby-plugin-theme-ui": "^0.3.0",
     "gatsby-plugin-typescript": "^2.4.17",
+    "gatsby-remark-autolink-headers": "^2.3.11",
     "gatsby-remark-external-links": "0.0.4",
     "gatsby-remark-images": "^3.3.25",
     "gatsby-remark-prismjs": "^3.5.10",

--- a/src/templates/docs.tsx
+++ b/src/templates/docs.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { graphql } from "gatsby";
 import { MDXRenderer } from "gatsby-plugin-mdx";
 import { Flex, Box } from "@theme-ui/components";
+import { Global, css } from "@emotion/core";
 import SEO from "../components/seo";
 import { DocsNavigation } from "../components/docs-navigation";
 import { DocsPageQuery } from "./__generated__/DocsPageQuery";
@@ -10,6 +11,15 @@ import { EditOnGithub } from "../components/edit-on-github";
 const DocsPage = ({ data: { file } }: { data: DocsPageQuery }) => (
   <>
     <SEO title={file.childMdx.frontmatter.title} />
+
+    <Global
+      styles={css`
+        a.anchor.before {
+          position: absolute;
+          left: -1.5rem;
+        }
+      `}
+    />
 
     <Flex
       sx={{


### PR DESCRIPTION
Add [gatsby-remark-autolink-headers](https://www.gatsbyjs.com/plugins/gatsby-remark-autolink-headers/) so that headers can be linked directly to. 

<img width="983" alt="Screenshot 2020-08-27 at 15 17 14" src="https://user-images.githubusercontent.com/691952/91454121-8139f480-e878-11ea-8768-d5218f064b71.png">


Note: the header links are displayed all the time (as opposed to just on hover) so that nothing special needs to be done on mobile.