### PR TITLE
Use custom domain for stats

### DIFF
--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -98,7 +98,7 @@ const SEO: React.SFC<SEOProps> = ({
             async
             defer
             data-domain="strawberry.rocks"
-            src="https://plausible.io/js/plausible.js"
+            src="https://stats.strawberry.rocks/js/index.js"
           ></script>
         </Helmet>
       );


### PR DESCRIPTION
This should help with getting more stats as not all ad blockers will block the custom domain.

Plausible is a privacy friendly stats tool so I think we are good with this change 😊