### PR TITLE
Make newsletter placeholder easier to see on darkmode

### DIFF
--- a/src/components/newsletter-section.tsx
+++ b/src/components/newsletter-section.tsx
@@ -64,6 +64,9 @@ const Form: React.SFC = () => {
           border: "none",
           borderTopLeftRadius: 40,
           borderBottomLeftRadius: 40,
+          "&::placeholder": {
+            opacity: 1,
+          },
         }}
         onChange={e => setEmail(e.target.value)}
         value={email}


### PR DESCRIPTION
Small PR that makes the placeholder easier to read

Before:

![image](https://user-images.githubusercontent.com/3382153/97691967-03bc7b80-1a97-11eb-80d8-f1431cedd68c.png)


After:

![image](https://user-images.githubusercontent.com/3382153/97691997-0f0fa700-1a97-11eb-926f-35c1a61e5d5a.png)

To be honest I think it would look better white on dark mode but the color is the brand of the site so I can see why it's set that way.

It also makes it more clear on light mode as well:

Before:

![image](https://user-images.githubusercontent.com/3382153/97692055-277fc180-1a97-11eb-99fb-0845bee0d46f.png)


After:

![image](https://user-images.githubusercontent.com/3382153/97692083-323a5680-1a97-11eb-983e-68016daffcc5.png)
