### PR TITLE
Fix code block font family

### DIFF
--- a/src/gatsby-plugin-theme-ui/index.js
+++ b/src/gatsby-plugin-theme-ui/index.js
@@ -213,6 +213,7 @@ export default {
         color: TEXT_COLOR_DARK,
         backgroundColor: "muted",
         padding: 1,
+        fontFamily: "body",
       },
     },
     ul: {
@@ -230,6 +231,7 @@ export default {
         color: TEXT_COLOR_DARK,
         backgroundColor: "muted",
         padding: 1,
+        fontFamily: "body",
       },
     },
     a: {


### PR DESCRIPTION
Right now it uses `Courier` as font for `<code>` blocks