### PR TITLE
Add schema example code block

### DIFF
--- a/src/components/graphql-example.tsx
+++ b/src/components/graphql-example.tsx
@@ -22,7 +22,7 @@ function Header({ children, ...props }) {
   );
 }
 
-function CodeBlock({ language, children, ...props }) {
+function CodeBlock({ language, children, extraStyles = {}, ...props }) {
   return (
     <Prism
       className={`language-${language}`}
@@ -31,6 +31,7 @@ function CodeBlock({ language, children, ...props }) {
         borderTop: "none",
         maxHeight: "300px",
         overflowY: "auto",
+        ...extraStyles,
       }}
       {...props}
     >
@@ -58,7 +59,7 @@ export default function GraphQLExample({
         <Header>Query</Header>
         <CodeBlock
           language="graphql"
-          sx={{
+          extraStyles={{
             borderRight: "none",
           }}
         >
@@ -72,9 +73,7 @@ export default function GraphQLExample({
         }}
       >
         <Header>Result</Header>
-        <CodeBlock language="graphql">
-          {JSON.stringify(res, null, "  ")}
-        </CodeBlock>
+        <CodeBlock language="json">{JSON.stringify(res, null, "  ")}</CodeBlock>
       </Flex>
     </Flex>
   );

--- a/src/components/schema-example.tsx
+++ b/src/components/schema-example.tsx
@@ -1,0 +1,79 @@
+/** @jsx jsx */
+import { ReactElement } from "react";
+import { jsx } from "theme-ui";
+import { Flex, Box } from "@theme-ui/components";
+import Prism from "@theme-ui/prism";
+
+function Header({ children, ...props }) {
+  return (
+    <Box
+      sx={{
+        backgroundColor: "primary",
+        padding: 1,
+        color: "#fff",
+        paddingLeft: 2,
+        fontSize: 12,
+        fontFamily: "monospace",
+      }}
+      {...props}
+    >
+      {children}
+    </Box>
+  );
+}
+
+function CodeBlock({ language, children, extraStyles = {}, ...props }) {
+  return (
+    <Prism
+      className={`language-${language}`}
+      sx={{
+        flex: 1,
+        borderTop: "none",
+        maxHeight: "300px",
+        overflowY: "auto",
+        ...extraStyles,
+      }}
+      {...props}
+    >
+      {children}
+    </Prism>
+  );
+}
+
+export default function SchemaExample({
+  python,
+  schema,
+}: {
+  python: string;
+  schema: string;
+}): ReactElement {
+  return (
+    <Flex>
+      <Flex
+        sx={{
+          flex: 1,
+          flexDirection: "column",
+        }}
+      >
+        <Header>Definition</Header>
+        <CodeBlock
+          language="python"
+          extraStyles={{
+            borderRight: "none",
+          }}
+        >
+          {python}
+        </CodeBlock>
+      </Flex>
+      <Flex
+        sx={{
+          flex: 1,
+          flexDirection: "column",
+        }}
+      >
+        <Header>Schema</Header>
+        <CodeBlock language="graphql">{schema}</CodeBlock>
+      </Flex>
+    </Flex>
+  );
+}

--- a/src/gatsby-plugin-theme-ui/components.js
+++ b/src/gatsby-plugin-theme-ui/components.js
@@ -5,6 +5,7 @@ import Prism from "@theme-ui/prism";
 import { AdditionalResources } from "../components/additional-resources";
 import { Link } from "../components/link";
 import GraphQLExample from "../components/graphql-example.tsx";
+import SchemaExample from "../components/schema-example.tsx";
 
 const getImageSrc = src => {
   if (src.startsWith("./")) {
@@ -26,6 +27,14 @@ function CustomPrism({ className, children, ...props }) {
       throw new Error("Invalid content for language `graphql+response`");
     }
     return <GraphQLExample query={query} response={response} />;
+  }
+
+  if (language === "python+schema") {
+    const [python, schema] = children.split("---");
+    if (!python || !schema) {
+      throw new Error("Invalid content for language `python+schema`");
+    }
+    return <SchemaExample python={python} schema={schema} />;
   }
 
   return (


### PR DESCRIPTION
Like the graphql example block: this PR adds a new custom language `python+schema` to display the python definition and the resulting schema side by side:

<img width="984" alt="Screenshot 2020-10-31 at 11 19 10" src="https://user-images.githubusercontent.com/691952/97777887-05f00a00-1b6b-11eb-8e45-2ce05df83e9f.png">

It also fixes a bug with the graphql example block where the code wasn't being highlighted correctly.