### PR TITLE
fix: discord logo color

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx, useColorMode, Box, Flex } from "theme-ui";
+import { jsx, Box, Flex } from "theme-ui";
 
 import { Link } from "./link";
 import { Logo } from "./logo";
@@ -20,8 +20,6 @@ type GithubRelease = {
 export const Header: React.FC<{ latestVersion: string }> = ({
   latestVersion,
 }) => {
-  const [colorMode] = useColorMode();
-
   return (
     <Box
       as="header"
@@ -74,7 +72,7 @@ export const Header: React.FC<{ latestVersion: string }> = ({
               sx={{
                 height: 30,
                 verticalAlign: "middle",
-                fill: colorMode === "dark" ? "white" : "black",
+                fill: "text",
               }}
             >
               <path d="M142.8 120.1c-5.7 0-10.2 4.9-10.2 11s4.6 11 10.2 11c5.7 0 10.2-4.9 10.2-11s-4.6-11-10.2-11zM106.3 120.1c-5.7 0-10.2 4.9-10.2 11s4.6 11 10.2 11c5.7 0 10.2-4.9 10.2-11 .1-6.1-4.5-11-10.2-11z" />

--- a/theme.ts
+++ b/theme.ts
@@ -24,6 +24,7 @@ const theme: Readonly<Theme> = {
   },
 
   useColorSchemeMediaQuery: true,
+  useLocalStorage: false,
 
   colors: {
     text: TEXT_COLOR_DARK,


### PR DESCRIPTION
The discord logo color was not changing client side. This was caused by SSR/static renders of the page having the theme color set to 'default' at render and the classname on the svg element being set. 
## Fix
- using a css variable for the fill color of the discord logo svg. This is changed on the body element when the theme color mode is changed. 

- disabled the [localstorage](https://dev.theme-ui.com/color-modes#disable-persisting-color-mode-on-localstorage) that saves the theme color mode as there is no ui for the user to change the theme. We just want to use the browser/os media query [useColorSchemeMediaQuery](https://dev.theme-ui.com/color-modes#responding-to-the-prefers-color-scheme-media-query)

### Before
![Screen Shot 2021-02-07 at 18 18 30](https://user-images.githubusercontent.com/4893048/107155580-1a654f00-6971-11eb-8647-abdb44236d08.png)

### After
![Screen Shot 2021-02-07 at 18 17 52](https://user-images.githubusercontent.com/4893048/107155581-1b967c00-6971-11eb-9fec-928b95d2dd71.png)

