### PR TITLE
feat: reduce GitHub GraphQL API queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ This repo only contains the template and design of the website.
 **This shows the latest released version and not the master branch docs.**
 #### `https://strawberry.rocks/docs`
 
-Shows the latest [release](https://github.com/strawberry-graphql/strawberry/releases) from [Strawberry Graphql Repo]. These pages are rendered at build time and revalidated after 30 seconds. When a new release of Strawberry Graphql is done then the site should update [Strawberry GraphQL](https://strawberry.rocks) site by itself. Not requiring a re-deployment. 
+Shows the latest [release](https://github.com/strawberry-graphql/strawberry/releases) from [Strawberry Graphql Repo]. These pages are rendered at build time and revalidated after 60 seconds. When a new release of Strawberry Graphql is done then the site should update [Strawberry GraphQL](https://strawberry.rocks) site by itself. Not requiring a re-deployment. 
 
 ### Pull Requests
 
 #### `https://strawberry.rocks/docs/pr/:pull-request-number`
 
-Pull requests on [Strawberry Graphql Repo] with a label of [ok-to-preview](https://github.com/strawberry-graphql/strawberry/pulls?q=is%3Apr+is%3Aopen+label%3Aok-to-preview) can be viewed. Theses are rendered on-demand and cached. They will be revalidated after 30 seconds.
+Pull requests on [Strawberry Graphql Repo] with a label of [ok-to-preview](https://github.com/strawberry-graphql/strawberry/pulls?q=is%3Apr+is%3Aopen+label%3Aok-to-preview) can be viewed. Theses are rendered on-demand and cached. They will be revalidated after 60 seconds.
 
 ### Version Releases
 

--- a/components/link.tsx
+++ b/components/link.tsx
@@ -53,7 +53,7 @@ const LinkWrapper: React.FC<{
   }
 
   return (
-    <NextLink href={href} as={as} passHref>
+    <NextLink prefetch={false} href={href} as={as} passHref>
       <ThemeLink {...rest} className={className}>
         {children}
       </ThemeLink>

--- a/lib/doc-tree.ts
+++ b/lib/doc-tree.ts
@@ -1,0 +1,48 @@
+import marked, { Tokens } from "marked";
+
+import { DocsTree } from "~/components/docs-navigation";
+import { addHrefPrefix } from "~/helpers/params";
+import {
+  isHeading,
+  isLink,
+  isList,
+  isListItemWithTokens,
+  isTextWithTokens,
+} from "~/helpers/type-guards";
+
+export const getMDLinks = (items: Tokens.ListItem[]): Tokens.Link[] =>
+  items.filter(isListItemWithTokens).flatMap((item) =>
+    item.tokens
+      .filter(isTextWithTokens)
+      .flatMap((t) => t.tokens)
+      .filter(isLink)
+  );
+
+export function getDocTree(text: string, prefix: string) {
+  const sections: DocsTree = {};
+  const tokens = marked.lexer(text);
+
+  let currentSection = "Docs";
+
+  tokens.forEach((token) => {
+    if (isHeading(token) && token.depth === 2) {
+      currentSection = token.text;
+    }
+
+    if (isList(token)) {
+      if (typeof sections[currentSection] === "undefined") {
+        sections[currentSection] = {
+          name: currentSection,
+          links: [],
+        };
+      }
+
+      const links: Tokens.Link[] = getMDLinks(token.items);
+      sections[currentSection].links = links.map((link) => ({
+        href: addHrefPrefix(link.href, prefix),
+        text: link.text,
+      }));
+    }
+  });
+  return sections;
+}

--- a/pages/acknowledgements.tsx
+++ b/pages/acknowledgements.tsx
@@ -133,7 +133,7 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
       collaborators: await fetchContributors(),
       version: await fetchLatestRelease(),
     },
-    revalidate: 30,
+    revalidate: 60,
   };
 };
 

--- a/pages/code-of-conduct.tsx
+++ b/pages/code-of-conduct.tsx
@@ -79,7 +79,7 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
         source,
         version,
       },
-      revalidate: 30,
+      revalidate: 60,
     };
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/pages/docs/[[...slug]].tsx
+++ b/pages/docs/[[...slug]].tsx
@@ -70,12 +70,12 @@ export const getStaticProps: GetStaticProps<DocsPageProps> = async ({
     const editPath = `https://github.com/${owner}/${repo}/edit/${REF}/docs/${filename}`;
     return {
       props: { source, data, editPath, docsToc, version: ref },
-      revalidate: 30,
+      revalidate: 60,
     };
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error("getStaticProps:", error);
-    return { notFound: true, revalidate: 30 };
+    return { notFound: true, revalidate: 60 };
   }
 };
 

--- a/pages/docs/[[...slug]].tsx
+++ b/pages/docs/[[...slug]].tsx
@@ -10,9 +10,8 @@ import components from "~/components/theme-ui";
 import { fixImagePathsPlugin } from "~/helpers/image-paths";
 import { provider } from "~/helpers/next-mdx-remote";
 import {
-  fetchFile,
+  fetchDocPage,
   fetchLatestRelease,
-  fetchTableOfContents,
   fetchTableOfContentsPaths,
   OWNER,
   REF,
@@ -41,21 +40,21 @@ export const getStaticProps: GetStaticProps<DocsPageProps> = async ({
   const owner = OWNER;
   const repo = REPO;
 
-  const docsToc = await fetchTableOfContents({ prefix: "/docs/", ref });
-
   try {
     /**
      * Get doc content from markdown file.
      */
     const filename: string = slugs.join("/") + ".md";
-    const text = await fetchFile({
+
+    const { page, tableContent: docsToc } = await fetchDocPage({
+      prefix: "/docs/",
       filename: `docs/${filename}`,
       owner,
       repo,
       ref,
     });
 
-    const { data, content } = matter(text);
+    const { data, content } = matter(page);
     const source = await renderToString(content, {
       components,
       scope: data,

--- a/pages/docs/pr/[[...slug]].tsx
+++ b/pages/docs/pr/[[...slug]].tsx
@@ -9,7 +9,7 @@ import DocsPage, { DocsPageProps } from "~/components/doc";
 import components from "~/components/theme-ui";
 import { fixImagePathsPlugin } from "~/helpers/image-paths";
 import { provider } from "~/helpers/next-mdx-remote";
-import { fetchFile, fetchPullRequest, fetchTableOfContents } from "~/lib/api";
+import { fetchDocPage, fetchPullRequest } from "~/lib/api";
 
 export const getStaticPaths: GetStaticPaths = async () => {
   /**
@@ -57,13 +57,6 @@ export const getStaticProps: GetStaticProps<DocsPageProps> = async ({
       html_url,
     } = await fetchPullRequest({ pull_number: pullNumber });
 
-    const docsToc = await fetchTableOfContents({
-      prefix: `/docs/pr/${pull_number}/`,
-      ref: branch,
-      owner,
-      repo,
-    });
-
     /**
      * Shift slugs as we dont need the PR number for the filename.
      */
@@ -73,14 +66,15 @@ export const getStaticProps: GetStaticProps<DocsPageProps> = async ({
       throw new Error("no filename");
     }
 
-    const text = await fetchFile({
+    const { page, tableContent: docsToc } = await fetchDocPage({
+      prefix: `/docs/pr/${pull_number}/`,
       filename: `docs/${filename}`,
       owner,
       repo,
       ref: branch,
     });
 
-    const { data, content } = matter(text);
+    const { data, content } = matter(page);
     const source = await renderToString(content, {
       components,
       scope: data,

--- a/pages/docs/tag/[[...slug]].tsx
+++ b/pages/docs/tag/[[...slug]].tsx
@@ -9,7 +9,7 @@ import DocsPage, { DocsPageProps } from "~/components/doc";
 import components from "~/components/theme-ui";
 import { fixImagePathsPlugin } from "~/helpers/image-paths";
 import { provider } from "~/helpers/next-mdx-remote";
-import { fetchFile, fetchTableOfContents, OWNER, REPO } from "~/lib/api";
+import { fetchDocPage, OWNER, REPO } from "~/lib/api";
 
 export const getStaticPaths: GetStaticPaths = async () => {
   /**
@@ -38,13 +38,6 @@ export const getStaticProps: GetStaticProps<DocsPageProps> = async ({
   const repo = REPO;
 
   try {
-    const docsToc = await fetchTableOfContents({
-      prefix: `/docs/tag/${tag}/`,
-      ref: tag,
-      owner,
-      repo,
-    });
-
     /**
      * Shift slugs as we dont need the tag string for the filename.
      */
@@ -54,14 +47,15 @@ export const getStaticProps: GetStaticProps<DocsPageProps> = async ({
       throw new Error("no filename");
     }
 
-    const text = await fetchFile({
+    const { page, tableContent: docsToc } = await fetchDocPage({
+      prefix: `/docs/tag/${tag}/`,
       filename: `docs/${filename}`,
       owner,
       repo,
       ref: tag,
     });
 
-    const { data, content } = matter(text);
+    const { data, content } = matter(page);
     const source = await renderToString(content, {
       components,
       scope: data,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -78,7 +78,7 @@ const HomePage: NextPage<Props> = ({ version }) => (
 );
 
 export const getStaticProps: GetStaticProps<Props> = async () => {
-  return { props: { version: await fetchLatestRelease() }, revalidate: 30 };
+  return { props: { version: await fetchLatestRelease() }, revalidate: 60 };
 };
 
 export default HomePage;

--- a/types/graphql.d.ts
+++ b/types/graphql.d.ts
@@ -19060,3 +19060,13 @@ export type CodeOfConductQueryVariables = Exact<{
 
 
 export type CodeOfConductQuery = { repository?: Maybe<{ codeOfConduct?: Maybe<Pick<CodeOfConduct, 'body'>>, latestRelease?: Maybe<Pick<Release, 'tagName'>> }> };
+
+export type DocPageQueryVariables = Exact<{
+  owner: Scalars['String'];
+  repo: Scalars['String'];
+  filename: Scalars['String'];
+  tablecontent: Scalars['String'];
+}>;
+
+
+export type DocPageQuery = { repository?: Maybe<{ object?: Maybe<Pick<Blob, 'text'>>, tableOfContents?: Maybe<Pick<Blob, 'text'>> }> };


### PR DESCRIPTION
It appears we are hitting the GitHub GraphQL API query limit from the error logs on vercel.

To reduce the API calls I have

- combined the docs page and table contents page into one graphql query.
- disabled nextjs link from prefetching links on the page. They still prefetch on hover.