### PR TITLE
feat: next/image component

### DIFF
--- a/components/theme-ui.tsx
+++ b/components/theme-ui.tsx
@@ -4,6 +4,8 @@ import Prism, { ThemeUIPrismProps } from "@theme-ui/prism";
 import GithubSlugger from "github-slugger";
 import { jsx, ThemeUICSSObject, ImageProps } from "theme-ui";
 
+import Image from "next/image";
+
 import { AdditionalResources } from "./additional-resources";
 import GraphQLExample from "./graphql-example";
 import SchemaExample from "./schema-example";
@@ -26,14 +28,12 @@ const DocsLink = ({
 };
 
 const DocsImage = ({ src, ...props }: ImageProps) => (
-  <img
-    sx={{
-      borderWidth: 2,
-      maxWidth: "100%",
-      borderColor: "muted",
-      borderStyle: "solid",
-    }}
-    src={src}
+  <Image
+    layout="responsive"
+    width="100%"
+    height="auto"
+    objectFit="contain"
+    src={src ?? ""}
     {...props}
   />
 );

--- a/next.config.js
+++ b/next.config.js
@@ -19,5 +19,8 @@ module.exports = withTM(
         },
       ];
     },
+    images: {
+      domains: ["github.com", "raw.githubusercontent.com"],
+    },
   })
 );


### PR DESCRIPTION
closes #39 

Use next image component to optimize images. See [docs](https://nextjs.org/docs/basic-features/image-optimization).

The current next.js image component uses a `<div>` wrapper and `padding-top` to make the img responsive. Ideally we would remove this wrapper and use simpler css. But that is not supported at the moment. So images have padding top and bottom and there is no red border.

<img width="601" alt="CleanShot 2021-02-21 at 18 09 25@2x" src="https://user-images.githubusercontent.com/4893048/108634284-d3974f00-7470-11eb-9d78-3fc8ab57e0b3.png">
