### PR TITLE
Add Tip, Note and Warning blocks

### DIFF
--- a/components/mdx.tsx
+++ b/components/mdx.tsx
@@ -183,8 +183,18 @@ const CodeNotes = ({
   );
 };
 
-const BaseBlock = ({ heading, color, children}: { heading: string, color: string, children: ReactNode }) => (
-  <div className={`border-l-4 border-${color}-500 shadow-sm mb-4 overflow-auto`}>
+const BaseBlock = ({
+  heading,
+  color,
+  children,
+}: {
+  heading: string;
+  color: string;
+  children: ReactNode;
+}) => (
+  <div
+    className={`border-l-4 border-${color}-500 shadow-sm mb-4 overflow-auto`}
+  >
     <div className={`bg-${color}-100 py-2 px-3 mb-2 font-bold`}>{heading}</div>
     <blockquote className="px-3">{children}</blockquote>
   </div>

--- a/components/mdx.tsx
+++ b/components/mdx.tsx
@@ -183,6 +183,31 @@ const CodeNotes = ({
   );
 };
 
+const BaseBlock = ({ heading, color, children}: { heading: string, color: string, children: ReactNode }) => (
+  <div className={`border-l-4 border-${color}-500 shadow-sm mb-4 overflow-auto`}>
+    <div className={`bg-${color}-100 py-2 px-3 mb-2 font-bold`}>{heading}</div>
+    <blockquote className="px-3">{children}</blockquote>
+  </div>
+);
+
+const NoteBlock = ({ children }: { children: ReactNode }) => (
+  <BaseBlock color="blue" heading="Note">
+    {children}
+  </BaseBlock>
+);
+
+const TipBlock = ({ children }: { children: ReactNode }) => (
+  <BaseBlock color="green" heading="Tip">
+    {children}
+  </BaseBlock>
+);
+
+const WarningBlock = ({ children }: { children: ReactNode }) => (
+  <BaseBlock color="yellow" heading="Warning">
+    {children}
+  </BaseBlock>
+);
+
 const theme = {
   h1: heading(1),
   h2: heading(2),
@@ -205,6 +230,9 @@ const theme = {
   img: DocsImage,
   CodeNotes,
   SplitCodeView,
+  Note: NoteBlock,
+  Tip: TipBlock,
+  Warning: WarningBlock,
 };
 
 export default theme;

--- a/components/mdx.tsx
+++ b/components/mdx.tsx
@@ -189,31 +189,43 @@ const BaseBlock = ({
   children,
 }: {
   heading: string;
-  color: string;
+  color: "green" | "blue" | "yellow";
   children: ReactNode;
 }) => (
   <div
-    className={`border-l-4 border-${color}-500 shadow-sm mb-4 overflow-auto`}
+    className={cx("border-l-4 shadow-sm mb-4 overflow-auto", {
+      "border-green-500": color === "green",
+      "border-blue-500": color === "blue",
+      "border-yellow-500": color === "yellow",
+    })}
   >
-    <div className={`bg-${color}-100 py-2 px-3 mb-2 font-bold`}>{heading}</div>
+    <div
+      className={cx("py-2 px-3 mb-2 font-bold", {
+        "bg-green-100": color === "green",
+        "bg-blue-100": color === "blue",
+        "bg-yellow-100": color === "yellow",
+      })}
+    >
+      {heading}
+    </div>
     <blockquote className="px-3">{children}</blockquote>
   </div>
 );
 
 const NoteBlock = ({ children }: { children: ReactNode }) => (
-  <BaseBlock color="blue" heading="Note">
+  <BaseBlock color="blue" heading="📝 Note">
     {children}
   </BaseBlock>
 );
 
 const TipBlock = ({ children }: { children: ReactNode }) => (
-  <BaseBlock color="green" heading="Tip">
+  <BaseBlock color="green" heading="💡 Tip">
     {children}
   </BaseBlock>
 );
 
 const WarningBlock = ({ children }: { children: ReactNode }) => (
-  <BaseBlock color="yellow" heading="Warning">
+  <BaseBlock color="yellow" heading="⚠️ Warning">
     {children}
   </BaseBlock>
 );


### PR DESCRIPTION
Add some components to call out parts of the docs as notes, tips or warnings.

I think the blockquote was being used for this at some point but we seem to have lost the styles. Anyway using components for this seems like a better option.

<img width="918" alt="CleanShot 2021-10-02 at 17 50 25@2x" src="https://user-images.githubusercontent.com/691952/135725593-915fcdba-7128-495c-8b0e-e12669c19bb5.png">
