### PR TITLE
fix code highlight for mobile and dark mode

### DIFF
--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -12,6 +12,7 @@
 .code-highlighted-line {
   opacity: 1;
   position: relative;
+  @apply w-fit;
 }
 
 .code-highlighted-line span {
@@ -28,7 +29,7 @@
   bottom: 1px;
   z-index: 0;
   display: block;
-  @apply bg-yellow-100;
+  @apply bg-yellow-100 dark:bg-sky-300/10;
 }
 
 .code-highlighted-word,


### PR DESCRIPTION
Fixes #343 
Issue:
Highlight doesn't have a dark mode and blows out the text colours
Highlight uses the width of the border box so text overflows
![image](https://user-images.githubusercontent.com/70145864/150508963-35f78cdc-fa0c-43f7-a6f0-b69dfef14ab7.png)

Preview of fix:
Highlighted lines are now are `bg-sky-300/10` for dark mode
Highlighted lines now fit to content using `w-fit`
![image](https://user-images.githubusercontent.com/70145864/150507443-ea0883cd-cc26-42e0-a4f4-ebca9cef57f0.png)
![image](https://user-images.githubusercontent.com/70145864/150507461-b77eb27d-5948-4e08-9012-d55ffbfaa2a9.png)
![image](https://user-images.githubusercontent.com/70145864/150507474-7ed72444-9c0d-435e-bdd0-a136987c1e5f.png)
