### PR TITLE
fix empty highlighted line

### DIFF
--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -12,7 +12,7 @@
 .code-highlighted-line {
   opacity: 1;
   position: relative;
-  @apply w-fit;
+  @apply w-fit min-w-[0.625rem];
 }
 
 .code-highlighted-line span {


### PR DESCRIPTION
Fix for my last PR where empty lines were not showing as highlighted
From:
![image](https://user-images.githubusercontent.com/70145864/150572550-3ef5c7ed-c059-4bbd-8893-1d1276fdd39b.png)

To:
![image](https://user-images.githubusercontent.com/70145864/150572429-af53a6d4-ef5e-4b54-a503-409446257520.png)
The idea behind this is that it mimics the behaviour of highlighting code in an IDE

