### PR TITLE
Promote opencollective on the startpage

### DIFF
--- a/apps/frontend/src/components/Home/Sponsors.astro
+++ b/apps/frontend/src/components/Home/Sponsors.astro
@@ -26,7 +26,7 @@ if (downloadsLastWeek < 100_000) {
     <h2 class="typography-heading-4">{message}</h2>
   </header>
 
-  <ButtonLink href="https://polar.sh/strawberry-graphql/subscriptions">
+  <ButtonLink href="https://opencollective.com/strawberry-graphql">
     Become a sponsor
   </ButtonLink>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR updates the "Become a Sponsor" link to point to Open Collective instead of Polar.

Our Open Collective just looks more attractive/active since Polar dropped the whole OSS donations aspect.

## Summary by Sourcery

Enhancements:
- Update sponsor link URL from Polar to Open Collective